### PR TITLE
resolve layergroup workspace proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugfixes
 
+* Fixed issue where layer group info objects were not properly resolving workspace info objects
+
 # 1.6.0
 
 ## Summary

--- a/src/stratus-redis-catalog/src/main/java/stratus/redis/cache/CachingCatalogFacade.java
+++ b/src/stratus-redis-catalog/src/main/java/stratus/redis/cache/CachingCatalogFacade.java
@@ -120,6 +120,10 @@ public class CachingCatalogFacade extends AbstractCatalogFacade  implements Cach
     private void resolveLayerGroup(LayerGroupInfo lg) {
         catalog.resolve(lg);
 
+        // TODO layergroup workspace proxies don't resolve anywhere, so we have to specifically resolve them.  Seems
+        //  something is amiss somewhere.  Until we discover where, this next line will handle the resolution.
+        lg.setWorkspace(ResolvingProxy.resolve(catalog, lg.getWorkspace()));
+
         List<PublishedInfo> layers = lg.getLayers();
         List<StyleInfo> styles = lg.getStyles();
 


### PR DESCRIPTION
CachingCatalogFacade does not resolve workspace objects, which causes issues during serialization.  This PR resolves fixes the issue by specifically resolving the workspace proxies in layer group info objects.